### PR TITLE
FIX add import for version in weaver

### DIFF
--- a/doc/lmt/lmw.rb.md
+++ b/doc/lmt/lmw.rb.md
@@ -129,7 +129,7 @@ We have the dependencies.  Optparse and methadone are used for cli argument hand
 ``` ruby
 require 'optparse'
 require 'methadone'
-
+require 'lmt/version'
 require 'pry'
 ```
 

--- a/lib/lmt/lmw.rb
+++ b/lib/lmt/lmw.rb
@@ -3,7 +3,7 @@
 
 require 'optparse'
 require 'methadone'
-
+require 'lmt/version'
 require 'pry'
 require 'pathname'
 

--- a/src/lmt/lmw.rb.lmd
+++ b/src/lmt/lmw.rb.lmd
@@ -117,7 +117,7 @@ We have the dependencies.  Optparse and methadone are used for cli argument hand
 ``` ruby includes
 require 'optparse'
 require 'methadone'
-
+require 'lmt/version'
 require 'pry'
 ```
 


### PR DESCRIPTION
# Context

When installed as a gem 'tangle' would work but 'weaver' would exit with an error due to line 214 in lmw.rb
This was caused by a missing import

# Changes

Added the import for 'lmt/version'